### PR TITLE
Fix DocketManager attribute passthrough

### DIFF
--- a/docketanalyzer/docket/docket_manager.py
+++ b/docketanalyzer/docket/docket_manager.py
@@ -131,11 +131,6 @@ class DocketManager:
         if name in index_attributes:
             return getattr(object.__getattribute__(self, "index"), name)
 
-        batch_attributes = ["hello"]
-        if name in batch_attributes:
-            batch = object.__getattribute__(self, "batch")
-            return getattr(batch, name)
-
         return object.__getattribute__(self, name)
 
     def __repr__(self) -> str:

--- a/tests/test_docket_manager.py
+++ b/tests/test_docket_manager.py
@@ -1,0 +1,15 @@
+import tempfile
+from pathlib import Path
+import pytest
+
+from docketanalyzer.docket import DocketIndex
+
+
+def test_unknown_attribute_error():
+    """Accessing an unknown attribute should raise AttributeError."""
+    tmp_dir = Path(tempfile.mkdtemp())
+    index = DocketIndex(tmp_dir)
+    manager = index["test__1"]
+    with pytest.raises(AttributeError):
+        _ = manager.hello
+


### PR DESCRIPTION
## Summary
- clean up passthrough logic in `DocketManager.__getattribute__`
- add regression test ensuring unknown attributes raise `AttributeError`

## Testing
- `pytest -q` *(fails: `pytest` not installed)*