### PR TITLE
Fix Fahrenheit spelling in WeatherTool

### DIFF
--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -10,7 +10,7 @@ class WeatherTool(Tool):
 
     def __call__(self, agent=None):
         """Mock tool call."""
-        return f"The weather in {self.location} is 72 degrees farenheit."
+        return f"The weather in {self.location} is 72 degrees Fahrenheit."
 
 
 class WeatherAgent(Agent):


### PR DESCRIPTION
## Summary
- correct WeatherTool output spelling

## Testing
- `pytest -m 'not (cost or local)'` *(fails: TypeError, missing credentials)*