### PR TITLE
Improve S3 path handling

### DIFF
--- a/docketanalyzer/services/s3.py
+++ b/docketanalyzer/services/s3.py
@@ -1,7 +1,7 @@
 import os
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import boto3
 from botocore.client import Config
@@ -131,7 +131,13 @@ class S3:
                 path = path.relative_to(self.data_dir)
             from_path = to_path = path
 
-        return Path(cast(str | Path, from_path)), Path(cast(str | Path, to_path))
+        if path is None and from_path is None and to_path is None:
+            raise ValueError("Must provide at least one path argument")
+
+        from_path = Path() if from_path is None else Path(from_path)
+        to_path = Path() if to_path is None else Path(to_path)
+
+        return from_path, to_path
 
     def push(
         self,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,6 +1,7 @@
 import shutil
 from contextlib import suppress
 from datetime import datetime
+from pathlib import Path
 
 import botocore
 import pandas as pd
@@ -15,6 +16,7 @@ from docketanalyzer import (
     load_redis,
     load_s3,
 )
+from docketanalyzer.services.s3 import S3
 
 
 @pytest.fixture(scope="session")
@@ -265,3 +267,20 @@ def test_s3_push_and_pull(temp_data_dir, dummy_data):
     s3.pull(temp_data_dir)
 
     assert not path.exists()
+
+
+def test_prepare_paths_defaults(temp_data_dir):
+    """`_prepare_paths` defaults missing paths to `.` and errors if all missing."""
+    s3 = S3.__new__(S3)
+    s3.data_dir = temp_data_dir
+
+    from_path, to_path = s3._prepare_paths(None, "src", None)
+    assert from_path == Path("src")
+    assert to_path == Path()
+
+    from_path, to_path = s3._prepare_paths(None, None, "dst")
+    assert from_path == Path()
+    assert to_path == Path("dst")
+
+    with pytest.raises(ValueError):
+        s3._prepare_paths(None, None, None)


### PR DESCRIPTION
## Summary
- handle missing path arguments in `_prepare_paths`
- test defaulting behaviour of `_prepare_paths`

## Testing
- `ruff check`
- `pytest -q tests/test_services.py::test_prepare_paths_defaults -q`
- `pytest -q` *(fails: ANTHROPIC_API_KEY, OPENAI_API_KEY, COHERE_API_KEY, GROQ_API_KEY, TOGETHER_API_KEY, ELASTIC_URL, POSTGRES_URL, REDIS_URL, AWS_S3_BUCKET_NAME are not set)*