### PR TITLE
Remove custom delete method

### DIFF
--- a/docketanalyzer/services/psql.py
+++ b/docketanalyzer/services/psql.py
@@ -65,21 +65,6 @@ class CustomQueryMixin:
         """
         return self.order_by(peewee.fn.Random()).limit(n)
 
-    def delete(self) -> int:
-        """Delete all records matching the query.
-
-        This method constructs a delete query using a subquery to find matching
-        records based on the primary key and executes it.
-
-        Returns:
-            int: Number of records deleted
-        """
-        model_class = self.model
-        subquery = self.select(model_class._meta.primary_key)
-        delete_query = model_class.delete().where(
-            model_class._meta.primary_key.in_(subquery)
-        )
-        return delete_query.execute()
 
     def batch(
         self, n: int, verbose: bool = True

--- a/docs/utils/services.md
+++ b/docs/utils/services.md
@@ -82,7 +82,6 @@ standard Peewee interface:
   large transfers.
 - `sample(n)` returns a randomly sampled query.
 - `batch(n, verbose=True)` yields query results in chunks of `n` rows.
-- `delete()` performs a subquery delete for the current selection.
 - Instances provide `dict()` for easy serialization.
 
 Example usage:
@@ -99,7 +98,7 @@ for batch in users.sample(100).batch(25, verbose=False):
     process(batch.pandas())
 
 # delete by condition
-users.where(users.email == "bob@example.com").delete()
+users.delete().where(users.email == "bob@example.com").execute()
 ```
 
 ### Modifying tables

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -140,7 +140,7 @@ def test_psql_schemaless_table(dummy_data, db_with_test_table):
     assert len(data) == 1
 
     # Test delete functionality
-    table.where(table.email == "bob@example.com").delete()
+    table.delete().where(table.email == "bob@example.com").execute()
 
     data = table.pandas("email")["email"].tolist()
 


### PR DESCRIPTION
## Summary
- remove `CustomQueryMixin.delete()` to avoid automatic subquery deletes
- update docs to use Peewee's standard delete
- adjust unit test for new delete style

## Testing
- `pytest -q` *(fails: OpenAI/psql/etc. network errors)*
- `mkdocs build --strict`
